### PR TITLE
using env for cookie name

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -5,6 +5,7 @@ pub struct Config {
     pub jwt_max_age_mins: i64,
     pub port: u16,
     pub post_mark_config: PostMarkConfig,
+    pub auth_cookie_name: String,
 }
 
 #[derive(Clone)]
@@ -25,6 +26,8 @@ impl Config {
         let mail_server_token = std::env::var("POSTMARK_SERVER_TOKEN")
             .expect("POSTMARK_SERVER_TOKEN IS NOT SET IN THE ENV");
 
+        let auth_cookie_name =
+            std::env::var("COOKIE_NAME").expect("COOKIE_NAME IS NOT SET IN THE ENV");
         Config {
             database_url,
             jwt_secret,
@@ -36,6 +39,7 @@ impl Config {
                 mail_from_email,
                 server_token: mail_server_token,
             },
+            auth_cookie_name,
         }
     }
 }

--- a/api/src/middleware/auth.rs
+++ b/api/src/middleware/auth.rs
@@ -62,8 +62,9 @@ where
     }
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
+        let app_state = req.app_data::<web::Data<AppState>>().unwrap();
         let token = req
-            .cookie("token")
+            .cookie(app_state.config.auth_cookie_name.as_str())
             .map(|c| c.value().to_owned())
             .or_else(|| {
                 req.headers()
@@ -79,7 +80,6 @@ where
             };
             return Box::pin(ready(Err(ErrorUnauthorized(json_error))));
         }
-        let app_state = req.app_data::<web::Data<AppState>>().unwrap();
 
         let user_id = match utils::token::decode_token(
             token.unwrap(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Authentication cookie name is now configurable via environment settings, allowing customization of the session identifier used by the authentication system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->